### PR TITLE
Update Test for Forwarder

### DIFF
--- a/test/Forwarder.js
+++ b/test/Forwarder.js
@@ -44,7 +44,7 @@ describe(NAME, function () {
       );
       expect(
         attackerWalletBalanceAfter.sub(attackerWalletBalanceBefore)
-      ).to.be.equal(ethers.utils.parseEther("1"));
+      ).to.be.closeTo(ethers.utils.parseEther("1"), 1000000000000000);
 
       const walletContractBalance = await ethers.provider.getBalance(
         walletContract.address


### PR DESCRIPTION
Changed `to.be.equal` for `to.be.closeTo`, as gas matter.