### PR TITLE
fix non compiling viceroy riddle contract

### DIFF
--- a/contracts/Viceroy.sol
+++ b/contracts/Viceroy.sol
@@ -10,7 +10,7 @@ contract OligarchyNFT is ERC721 {
         _mint(attacker, 1);
     }
 
-    function _beforeTokenTransfer(address from, address, uint256, uint256) internal virtual {
+    function _beforeTokenTransfer(address from, address, uint256, uint256) internal virtual override {
         require(from == address(0), "Cannot transfer nft"); // oligarch cannot transfer the NFT
     }
 }


### PR DESCRIPTION
fix non compiling viceroy riddle contract which does not have the override modifier to the _beforeTokenTransfer function