### PR TITLE
Updated solidity version to 0.8.20;

### DIFF
--- a/contracts/Overmint1.sol
+++ b/contracts/Overmint1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity 0.8.15;
+pragma solidity 0.8.20;
 import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 


### PR DESCRIPTION
Updated solidity version to 0.8.20; 

To solve the compile time error

```
ParserError: Source file requires different compiler version (current compiler is 0.8.15+commit.e14f2714.Emscripten.clang).
```